### PR TITLE
Exempt 'main' and 'develop' from branch naming rules

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Validate branch name
         run: |
           BRANCH_NAME=${{ github.ref_name }}
+          if [[ $BRANCH_NAME == "main" || $BRANCH_NAME == "develop" ]]; then
+            echo "Branch '$BRANCH_NAME' is exempt from naming convention."
+            exit 0
+          fi
           if [[ ! $BRANCH_NAME =~ ^(feat|fix|perf|docs|style|refactor|test|build)\/.* ]]; then
             echo "Erro: O nome da branch '$BRANCH_NAME' não segue o padrão '<tipo>/', onde tipo deve ser: feat, fix, hotfix, refactor, docs ou test."
             exit 1


### PR DESCRIPTION
Added exemption for 'main' and 'develop' branches in naming validation.